### PR TITLE
Some other HTML errors

### DIFF
--- a/_demo/pages/04.shortcodes/default.md
+++ b/_demo/pages/04.shortcodes/default.md
@@ -105,7 +105,7 @@ This is a danger small button in block [sc-button type="danger" url="https://get
 
 ### Example
 
-This is a primary button [sc-button type="success" url="https:/getgrav.org" label="Button" target="blank" size="lg" classes=""][/sc-button]
+This is a primary button [sc-button type="success" url="https://getgrav.org" label="Button" target="blank" size="lg" classes=""][/sc-button]
 
 This is a danger small button [sc-button type="danger" url="https://getgrav.org" label="Button" target="blank" size="sm" classes=""][/sc-button]
 

--- a/languages.yaml
+++ b/languages.yaml
@@ -89,7 +89,7 @@ en:
             SHOW_RELATED_PAGES: Show Related Pages
             SHOW_RELATED_PAGES_HELP: 'Related pages plugin must be installed'
             SHOW_FEEDS: Show Feeds
-            SHOW_FEEDS_HELP: 'Feeds plugin must be installed'
+            SHOW_FEEDS_HELP: 'Feed plugin must be installed'
             SHOW_RANDOM: Show Random Post
             SHOW_RANDOM_HELP: 'Random plugin must be installed'
           CONFIGURATION:
@@ -343,7 +343,7 @@ es:
             SHOW_RELATED_PAGES: Mostrar Páginas Relacionadas
             SHOW_RELATED_PAGES_HELP: 'El plugin Related pages debe estar instalado'
             SHOW_FEEDS: Mostrar Feeds
-            SHOW_FEEDS_HELP: 'El plugin Feeds debe estar instalado'
+            SHOW_FEEDS_HELP: 'El plugin Feed debe estar instalado'
             SHOW_RANDOM: Mostrar Publicación Aleatoria
             SHOW_RANDOM_HELP: 'El plugin Random debe estar instalado'
           CONFIGURATION:
@@ -567,7 +567,7 @@ fr:
           ICON_SIZE: Taille d'icône
           ICON: Icône de la barre de navigation
           ICON_HELP: Vous avez juste à écrire le nom de l'icône. Il ne sera visible que si le logo est désactivé.
-          ICON_DESCRIPTION: 'Mundana utilse les <a href="https://fontawesome.com/v5/search?o=r&f=brands" target="_blank">icones Fontawesome </a>'
+          ICON_DESCRIPTION: 'Mundana utilise les <a href="https://fontawesome.com/v5/search?o=r&f=brands" target="_blank">icônes Font Awesome </a>'
         CUSTOM_MENU:
           TITLE: Options du menu personnalisé
           ENABLED: 
@@ -598,7 +598,7 @@ fr:
             SHOW_RELATED_PAGES: Montrer les pages en relation
             SHOW_RELATED_PAGES_HELP: 'Le plugin Related pages doit être installé'
             SHOW_FEEDS: Montrer les flux de données
-            SHOW_FEEDS_HELP: 'Le plugin Feeds doit être installé'
+            SHOW_FEEDS_HELP: 'Le plugin Feed doit être installé'
             SHOW_RANDOM: Montrer un article au hasard
             SHOW_RANDOM_HELP: 'Le plugin Random doit être installé'
           CONFIGURATION:
@@ -608,7 +608,7 @@ fr:
             FEATURED_POSTS: 
               LABEL: Montrer les articles en vedette
               TAG: Étiquette des articles en vedette
-              TAG_HELP: "Saisir le nom de l'étiquette des articles en vedette.Vous devez inclure ce nom dans Options -> Taxonomy -> Étiquettes"
+              TAG_HELP: "Saisir le nom de l'étiquette des articles en vedette. Vous devez inclure ce nom dans Options -> Taxonomy -> Étiquettes"
               NUMBER: Nombre d'articles en vedette à montrer
               NUMBER_HELP: Nombre d'articles en vedette qui seront montrés dans le bandeau latéral
         SHARE:
@@ -620,13 +620,13 @@ fr:
           ICONS_DESCRIPTION: Voir les icônes disponibles dans <a href="https://www.addtoany.com/share/preferences" target="_blank">AddToAny</a>
           ICON_NAME: Nom de l'icône
         MAILCHIMP: 
-          SECTION: Configuration du mailchimp
-          ENABLED: Activer le mailchimp dans les articles
-          TITLE: Titre du mailchimp
-          TITLE_HELP: Saisir le titre pour la boîte du mailchimp
-          DESCRIPTION: Description du mailchimp
-          DESCRIPTION_HELP: Saisir un texte descriptif pour la boîte du mailchimp
-          ADDRESS: Adresse pou le mailchimp
+          SECTION: Configuration de Mailchimp
+          ENABLED: Activer Mailchimp dans les articles
+          TITLE: Titre de Mailchimp
+          TITLE_HELP: Saisir le titre pour la boîte de Mailchimp
+          DESCRIPTION: Description de Mailchimp
+          DESCRIPTION_HELP: Saisir un texte descriptif pour la boîte de Mailchimp
+          ADDRESS: Adresse pour Mailchimp
         DISQUS: 
           SECTION: Commentaires Disqus
           ENABLED: Activer les commentaires Disqus
@@ -636,7 +636,7 @@ fr:
           TEXT_RIGHT: Texte du pied de page droit
           TEXT_LEFT: Texte du pied de page gauche
           TEXT_RIGHT_HELP: Texte du pied de page situé à droite. Markdown et HTML supportés
-          TEXT_LEFT_HELP: Texte du pied de page situé à gauche. Markdown and HTML supportés
+          TEXT_LEFT_HELP: Texte du pied de page situé à gauche. Markdown et HTML supportés
       DEFAULT:
         CONTENT: Contenu
         SUBTITLE: Sous-titre
@@ -648,7 +648,7 @@ fr:
         IMAGE_OPTIONS: Options des images
         FEATURED_IMAGE: 
           LABEL: Image en vedette
-          HELP: Défini l'image pricipale de la page
+          HELP: Définir l'image principale de la page
           WIDTH: largeur
           HEIGHT: Hautreur
         SHOW_FEATURED_IMAGE: Montrer l'image
@@ -685,7 +685,7 @@ fr:
               BY_DATE: Date
               BY_TITLE: Titre
               BY_FOLDER: Dossier
-              BY_DEFAULT: Default
+              BY_DEFAULT: Défaut
               DIR: Direction
               DIR_ASC: Montant
               DIR_DESC: Descendant
@@ -710,7 +710,7 @@ fr:
             ENABLED: Résumé activé
             FORMAT: 
               LABEL: Format du résumé
-              SHORT: Utiliser la première occurence du délimiteur ou la taille
+              SHORT: Utiliser la première occurrence du délimiteur ou la taille
               LONG: Le délimiteur de résumé sera ignoré
             SIZE: Taille
             DELIMITER: Délimiteur de résumé
@@ -745,8 +745,8 @@ fr:
         LABEL: Catégories
         POSTS_IN: Publications dans
       FEATURED: En vedette
-      TAXONOMYLIST: Etiquettes populaires
-      RELATEDPAGES: Pages en rlation
+      TAXONOMYLIST: Étiquettes populaires
+      RELATEDPAGES: Pages en relation
       RANDOM_ARTICLE:
         LABEL: Un article au hazard
         BUTTON: Je vais avoir de la chance !

--- a/templates/default.html.twig
+++ b/templates/default.html.twig
@@ -18,7 +18,6 @@
                         {% if config.plugins.readingtime.enabled %}
                             {% include 'partials/blog/readingtime.html.twig' %}
                         {% endif %}
-                        </span>
                     </small>
                 </div>
             </div>

--- a/templates/modular/latestposts.html.twig
+++ b/templates/modular/latestposts.html.twig
@@ -44,7 +44,9 @@
                 </span>                   
         </small>
         <small class="d-block text-muted">
-            {% include 'partials/blog/date.html.twig' %}
+            {% include 'partials/blog/date.html.twig' with {
+                page: post
+            } %}
         </small>
     </div>
     </div>
@@ -82,7 +84,9 @@
                         </span>                   
                     </small>
                     <small class="d-block text-muted">
-                        {% include 'partials/blog/date.html.twig' %}
+                        {% include 'partials/blog/date.html.twig' with {
+                            page: post
+                        } %}
                     </small>
                 </div>
             </div>

--- a/templates/modular/latestposts.html.twig
+++ b/templates/modular/latestposts.html.twig
@@ -54,26 +54,25 @@
     
     <div class="col-md-6">
         {% for post in blog.children.order('date', 'desc').slice(1, 3) %}
-        {% set post_title = post.title|raw %}
         {% set blog_image = post.media.images[post.header.featuredImage] ?: post.media.images|filter((v, k) => k != post.header.author.avatarImage)|first %}
               
         <div class="mb-3 d-flex align-items-center">                
                 {% if (blog_image ?? null) %}
                 <div class="col-md-4">
-                <a href="{{post.url}}" title="{{ post_title }}" aria-label="{{ post_title }}">
+                <a href="{{post.url}}" title="{{ post.title|raw }}" aria-label="{{ post.title|raw }}">
                     {{ blog_image.loading('lazy')
                         .attribute('decoding','async')
                         .attribute('width', img_width)
                         .attribute('height', img_height)
                         .derivatives(320,672,320)
                         .sizes('(max-width: 768px) 100vw, 50vw')
-                        .html(title, title,'w-100 h-auto rounded')|raw }}
+                        .html(post.title, post.title,'w-100 h-auto rounded')|replace({'&amp;': '&'})|raw }}
                 </a>
                 </div>
                 {% endif %}                
                 <div class="col-md-8">
                     <h3 class="mb-2 h6 font-weight-bold">
-                    <a class="text-dark" href="{{post.url}}">{{ post_title }}</a>
+                    <a class="text-dark" href="{{post.url}}">{{ post.title|raw }}</a>
                     </h3>
                     <small class="d-block text-muted">
                         {{ 'MUNDANA.MISC.IN'|t }} <span class="catlist">

--- a/templates/partials/blog-item.html.twig
+++ b/templates/partials/blog-item.html.twig
@@ -38,7 +38,6 @@
                         {% if config.plugins.readingtime.enabled %}
                             {% include 'partials/blog/readingtime.html.twig' %}
                         {% endif %}
-                        </span>
                     </small>
                 </div>
             </div>

--- a/templates/partials/blog-list-item.html.twig
+++ b/templates/partials/blog-list-item.html.twig
@@ -31,7 +31,7 @@
             .attribute('height', '318')
 			.derivatives(320,424,320)
 			.sizes('(max-width: 768px) 100vw, 50vw')
-			.html(page_title|raw, page_title|raw,'w-100 h-auto rounded')|raw }}
+			.html(page_title, page_title,'w-100 h-auto rounded')|replace({'&amp;': '&'})|raw }}
 		</a>
 	</div>
 	{% endif %}

--- a/templates/partials/blog/date.html.twig
+++ b/templates/partials/blog/date.html.twig
@@ -1,9 +1,10 @@
 {# PARTIAL DATE FOR PAGES #}
 
 {% set datePublished = include('partials/page/date.html.twig') %}
+{% set dateTime = (page.header.publish_date) ? (page.header.publish_date|date("Y-m-d")) : (page.date ? page.date|date("Y-m-d") : page.modified|date("Y-m-d")) %}
 
 <span class="text-muted d-block mt-1">
-    <time datetime="{{ datePublished|date("Y-m-d") }}">
+    <time datetime="{{ dateTime }}">
         <i class="far fa-calendar-alt" aria-hidden="true"></i> {{ datePublished }}
     </time>
 </span>

--- a/templates/partials/blog/readingtime.html.twig
+++ b/templates/partials/blog/readingtime.html.twig
@@ -1,7 +1,7 @@
 {# PARTIAL READING TIME #}
 {#This code will work if the reading time plugin is enabled #}
 <span class="text-muted d-block mt-1">
-<time class="dt-published">
+    <time class="dt-published" datetime="PT{{ page.content|readingtime({'format': '{minutes_short_count}'}) }}M{{ page.content|readingtime({'format': '{seconds_short_count}'}) }}S">
         <i class="fas fa-clock"></i> {{ page.content|readingtime }}
     </time>
 </span>

--- a/templates/partials/blog/relatedpages.html.twig
+++ b/templates/partials/blog/relatedpages.html.twig
@@ -20,7 +20,7 @@
                 .attribute('height', img_height)
                 .derivatives(320,672,320)
                 .sizes('(max-width: 768px) 100vw, 50vw')
-                .html(related_title, related_title, 'w-100 h-auto mr-2 rounded')|raw }}
+                .html(related_title, related_title, 'w-100 h-auto mr-2 rounded')|replace({'&amp;': '&'})|raw }}
             </a>
 
             <div class="card-body">

--- a/templates/partials/sidebar/featured.html.twig
+++ b/templates/partials/sidebar/featured.html.twig
@@ -7,10 +7,10 @@
     <ol class="list-featured">
         {% for p in page.evaluate({'@taxonomy.tag':featuredposts_tag}).order('date', 'desc').slice(0,featuredposts_number) %}
             <li class="mb-4">
-                <span>
-                    <span class="h2 font-weight-bold h6">
+                <div>
+                    <h3 class="h2 font-weight-bold h6">
                         <a href="{{ p.url }}" class="text-dark">{{ p.title|raw }}</a>
-                    </span>
+                    </h3>
                     <span class="d-block text-muted">
                         {{ 'MUNDANA.MISC.IN'|t }}
                         <span class="catlist">
@@ -20,7 +20,7 @@
                             {% endfor %}
                         </span>
                     </span>
-                </span>
+                </div>
             </li>
         {% endfor %}
     </ol>

--- a/templates/partials/sidebar/relatedpages.html.twig
+++ b/templates/partials/sidebar/relatedpages.html.twig
@@ -7,7 +7,6 @@
     
     {% for related_path, score in related_pages %}
     {% set related = grav['pages'].get(related_path) %}
-    {% set related_title = related.title|raw %}
     {% set related_image = related.media.images[related.header.featuredImage] ?: related.media.images|filter((v, k) => k != related.header.author.avatarImage)|first %}
 
     {% if related %}
@@ -19,13 +18,13 @@
             .decoding('async')
             .attribute('width','100')
             .attribute('height','60')
-            .html(related_title, related_title, 'w-100 h-auto mr-2 rounded')|raw }}
+            .html(related.title, related.title, 'w-100 h-auto mr-2 rounded')|replace({'&amp;': '&'})|raw }}
         </div>
         {% endif %}
 
         <div class="col-8">
             <span class="font-weight-bold">
-                <a class="text-dark" href="{{ related.url }}" title="{{ related_title }}" rel="nofollow">{{ related_title }}</a>
+                <a class="text-dark" href="{{ related.url }}" title="{{ related.title|raw }}" rel="nofollow">{{ related.title|raw }}</a>
             </span>
             
             {% if related.taxonomy.category %}


### PR DESCRIPTION
In pull request #21, I only checked the home page.
Here are some suggestions to fix HTML errors on other pages (I hope I haven't forgotten any), based on messages returned by Nu Html Checker : https://validator.w3.org/nu/

The errors are as follows:
- _The text content of element time was not in the required format: The literal did not satisfy the time-datetime format._
	Correction of this error also solve "_Element i not allowed as child of element time in this context._"
- _Stray end tag span_ (2 occurrences)
- _Bad value https:/getgrav.org for attribute href on element a: Expected a slash ("/")._

For time duration in `templates/partials/blog/readingtime.html.twig`:
Solution based on : https://developer.mozilla.org/en-US/docs/Web/HTML/Reference/Elements/time
With the help of the documentation for the [ReadingTime Plugin](https://github.com/getgrav/grav-plugin-readingtime)

By the way, I propose an alternative solution to commit 2bc6cec to resolve the initial error ("_Element h3 not allowed as child of element span_") while preserving the original style.
