### PR TITLE
Allow to put all images in a single folder

### DIFF
--- a/templates/blog.html.twig
+++ b/templates/blog.html.twig
@@ -27,7 +27,7 @@
         {# Loading the first item as "eager" in the blog list greatly improves page speed #}
         {% set isFirstItem = true %}
         {% for child in collection %}
-            {% set childImage = child.media.images[child.header.featuredImage] ?: child.media.images|filter((v, k) => k != child.header.author.avatarImage)|first %}
+            {% set childImage = child.media[child.header.featuredImage] ?: child.media|filter((v, k) => k != child.header.author.avatarImage)|first %}
 			{% set childTitle = child.title|raw %}
             {% set child_showImage = child.header.show_image|defined(true) %}
             {% set datePublished = include('partials/page/date.html.twig', { 'page': child }) %}

--- a/templates/modular/allstories.html.twig
+++ b/templates/modular/allstories.html.twig
@@ -36,7 +36,7 @@
 			{# Loading the first item as "eager" in the blog list greatly improves page speed #}
 			{% set isFirstItem = true %}
 			{% for child in collection.slice(0, 5)%}
-				{% set childImage = child.media.images[child.header.featuredImage] ?: child.media.images|filter((v, k) => k != child.header.author.avatarImage)|first %}
+				{% set childImage = child.media[child.header.featuredImage] ?: child.media|filter((v, k) => k != child.header.author.avatarImage)|first %}
 				{% set childTitle = child.title|raw %}
 				{% set loadLazy = not isFirstItem %}
 				{% include 'partials/blog-list-item.html.twig' with { 

--- a/templates/modular/latestposts.html.twig
+++ b/templates/modular/latestposts.html.twig
@@ -22,7 +22,7 @@
 <div class="row my-5">
     <!-- latest post -->
     {% for post in blog.children.order('date', 'desc').slice(0, 1) %}
-    {% set blog_image = post.media.images[post.header.featuredImage] ?: post.media.images|filter((v, k) => k != post.header.author.avatarImage)|first %}
+    {% set blog_image = post.media[post.header.featuredImage] ?: post.media|filter((v, k) => k != post.header.author.avatarImage)|first %}
     <div class="col-md-6">
     <div class="card border-0 mb-4 box-shadow"> 
     {% if (blog_image ?? null) %}  
@@ -55,7 +55,7 @@
     <div class="col-md-6">
         {% for post in blog.children.order('date', 'desc').slice(1, 3) %}
         {% set post_title = post.title|raw %}
-        {% set blog_image = post.media.images[post.header.featuredImage] ?: post.media.images|filter((v, k) => k != post.header.author.avatarImage)|first %}
+        {% set blog_image = post.media[post.header.featuredImage] ?: post.media|filter((v, k) => k != post.header.author.avatarImage)|first %}
               
         <div class="mb-3 d-flex align-items-center">                
                 {% if (blog_image ?? null) %}

--- a/templates/modular/sticky.html.twig
+++ b/templates/modular/sticky.html.twig
@@ -20,7 +20,7 @@
 <!-- Sticky - add sticky tag to the post you want to highlight here - page.header.isSticky: true -->
 {% for post in blog.children %}
     {% if post.header.isSticky %}
-	{% set blog_image = post.media.images[post.header.featuredImage] ?: post.media.images|filter((v, k) => k != post.header.author.avatarImage)|first %}
+	{% set blog_image = post.media[post.header.featuredImage] ?: post.media|filter((v, k) => k != post.header.author.avatarImage)|first %}
 	{% set is_even = loop.index is even %}
 
 	<div class="jumbotron jumbotron-fluid jumbotron-home pt-0 pb-0 my-5 mb-2rem bg-lightblue position-relative">

--- a/templates/partials/base.html.twig
+++ b/templates/partials/base.html.twig
@@ -84,7 +84,7 @@
 {% set widthLogo = theme_var('custom_logo_width') %}
 
 {# Image settings #}
-{% set featuredImage = page.media[page.header.featuredImage] ?: page.media.images|filter((v, k) => k != page.header.author.avatarImage)|first %}
+{% set featuredImage = page.media[page.header.featuredImage] ?: page.media|filter((v, k) => k != page.header.author.avatarImage)|first %}
 {% set img_width = header_var('image_width')|default(672) %}
 {% set img_height = header_var('image_height')|default(504) %}
 {% set show_image = header_var('show_image')|defined(true) %}

--- a/templates/partials/blog/relatedpages.html.twig
+++ b/templates/partials/blog/relatedpages.html.twig
@@ -9,7 +9,7 @@
     {% set related = grav['pages'].get(related_path) %}
     {% set related_title = related.title|raw %}
     {% set related_author = related.header.author.name ?? related.taxonomy.author[0] %}
-    {% set related_image = related.media.images[related.header.featuredImage] ?: related.media.images|filter((v, k) => k != related.header.author.avatarImage)|first %}
+    {% set related_image = related.media[related.header.featuredImage] ?: related.media|filter((v, k) => k != related.header.author.avatarImage)|first %}
     {% if related %}
     <div class="col-sm-6 col-md-4 mb-4 mb-sm-0">
         <div class="card border-0">

--- a/templates/partials/sidebar/categories.html.twig
+++ b/templates/partials/sidebar/categories.html.twig
@@ -23,7 +23,7 @@
     {% for term in terms %}
         {% set blog_image = null %}
         {% for p in taxonomy.findTaxonomy({'category' : term}).order('date', 'desc').random(1) %}
-            {% set blog_image = p.media.images[p.header.featuredImage] ?: p.media.images|filter((v, k) => k != p.header.author.avatarImage)|first %}
+            {% set blog_image = p.media[p.header.featuredImage] ?: p.media|filter((v, k) => k != p.header.author.avatarImage)|first %}
         {% endfor %}
     <div class="row align-items-center py-2">
 		{% if blog_image %}

--- a/templates/partials/sidebar/relatedpages.html.twig
+++ b/templates/partials/sidebar/relatedpages.html.twig
@@ -8,7 +8,7 @@
     {% for related_path, score in related_pages %}
     {% set related = grav['pages'].get(related_path) %}
     {% set related_title = related.title|raw %}
-    {% set related_image = related.media.images[related.header.featuredImage] ?: related.media.images|filter((v, k) => k != related.header.author.avatarImage)|first %}
+    {% set related_image = related.media[related.header.featuredImage] ?: related.media|filter((v, k) => k != related.header.author.avatarImage)|first %}
 
     {% if related %}
     <div class="row align-items-center py-2">

--- a/templates/partials/simplesearch_item.html.twig
+++ b/templates/partials/simplesearch_item.html.twig
@@ -1,6 +1,6 @@
 <section class="row">
 
-    {% set blog_image = page.media.images[page.header.featuredImage] ?: page.media.images|filter((v, k) => k != page.header.author.avatarImage)|first %}
+    {% set blog_image = page.media[page.header.featuredImage] ?: page.media|filter((v, k) => k != page.header.author.avatarImage)|first %}
 
     {% if blog_image %}
         <div class="col-md-2">


### PR DESCRIPTION
Grav offers the option of placing all images in a single folder rather than in the page folders.
If I place the images in `user/images` and specify for example `featuredImage: image://blog8.webp` in the header of a page, in Mundana this only works for the page itself. However, the image no longer appears in _latestposts_, _allstories_, _relatedpages_, etc.

This is because the page image, displayed in `blog-item.html.twig`, is defined in `base.html.twig` 
with: `... set featuredImage = page.media[page.header.featuredImage] ...`

Whereas everywhere else, to retrieve the image in lists of items, the code is of this type: `... set childImage = child.media.images[child.header.featuredImage] ...`

I tested replacing all occurrences of **media.images** with **media** only, and it seems to work.

I did not modify `footer_pagination.html.twig`, where there are four occurrences of **media.images**, since the code works as is. Should it be modified as well?