### PR TITLE
Alternating texts and images for sticky posts

### DIFF
--- a/templates/modular/sticky.html.twig
+++ b/templates/modular/sticky.html.twig
@@ -19,8 +19,7 @@
 	</div>
 {% endif %}
 <!-- Sticky - add sticky tag to the post you want to highlight here - page.header.isSticky: true -->
-{% for post in collection %}
-    {% if post.header.isSticky %}
+{% for post in collection if post.header.isSticky %}
 	{% set blog_image = post.media.images[post.header.featuredImage] ?: post.media.images|filter((v, k) => k != post.header.author.avatarImage)|first %}
 	{% set is_even = loop.index is even %}
 
@@ -40,5 +39,4 @@
 			</div>
 		</div>
 	</div>
-	{% endif %}
 {% endfor %}


### PR DESCRIPTION
By wrapping the condition in the for loop, we ensure that **loop.index** is defined by **sticky posts only**.

In the initial code, the loop is defined by all blog posts, and those that need to be displayed may all be even or odd. This results in a loss of the expected aesthetic.